### PR TITLE
fix: 失败的request以字符串的形式存入redis

### DIFF
--- a/feapder/buffer/request_buffer.py
+++ b/feapder/buffer/request_buffer.py
@@ -80,7 +80,7 @@ class RequestBuffer(threading.Thread, Singleton):
         try:
             request_dict = request.to_dict
             self._db.zadd(
-                table or self._table_failed_request, request_dict, request.priority
+                table or self._table_failed_request, str(request_dict), request.priority
             )
         except Exception as e:
             log.exception(e)


### PR DESCRIPTION
redis版本问题，新版本不允许`dict`作为存储对象
fix #58 