### PR TITLE
支持浏览器渲染自定义添加参数配置

### DIFF
--- a/feapder/setting.py
+++ b/feapder/setting.py
@@ -68,6 +68,7 @@ WEBDRIVER = dict(
     window_size=(1024, 800),  # 窗口大小
     executable_path=None,  # 浏览器路径，默认为默认路径
     render_time=0,  # 渲染时长，即打开网页等待指定时间后再获取源码
+    custom_argument=['--ignore-certificate-errors']  # 自定义浏览器渲染参数
 )
 
 # 重新尝试失败的requests 当requests重试次数超过允许的最大重试次数算失败

--- a/feapder/utils/webdriver.py
+++ b/feapder/utils/webdriver.py
@@ -26,16 +26,17 @@ class WebDriver(RemoteWebDriver):
     PHANTOMJS = "PHANTOMJS"
 
     def __init__(
-        self,
-        load_images=True,
-        user_agent=None,
-        proxy=None,
-        headless=False,
-        driver_type=PHANTOMJS,
-        timeout=16,
-        window_size=(1024, 800),
-        executable_path=None,
-        **kwargs
+            self,
+            load_images=True,
+            user_agent=None,
+            proxy=None,
+            headless=False,
+            driver_type=PHANTOMJS,
+            timeout=16,
+            window_size=(1024, 800),
+            executable_path=None,
+            custom_argument=None,
+            **kwargs
     ):
         """
         webdirver 封装，支持chrome及phantomjs
@@ -57,6 +58,7 @@ class WebDriver(RemoteWebDriver):
         self._timeout = timeout
         self._window_size = window_size
         self._executable_path = executable_path
+        self.custom_argument = custom_argument
 
         self.proxies = {}
         self.user_agent = None
@@ -123,6 +125,10 @@ class WebDriver(RemoteWebDriver):
             chrome_options.add_argument(
                 "--window-size={},{}".format(self._window_size[0], self._window_size[1])
             )
+        # 添加自定义的配置参数
+        if self.custom_argument:
+            for arg in self.custom_argument:
+                chrome_options.add_argument(arg)
 
         if self._executable_path:
             driver = webdriver.Chrome(
@@ -162,6 +168,10 @@ class WebDriver(RemoteWebDriver):
             )
         if not self._load_images:
             service_args.append("--load-images=no")
+        # 添加自定义的配置参数
+        if self.custom_argument:
+            for arg in self.custom_argument:
+                service_args.append(arg)
 
         if self._executable_path:
             driver = webdriver.PhantomJS(


### PR DESCRIPTION
改了一下浏览器渲染这块，可以让我们自行添加一些WebDriver的参数，比如忽略证书错误。我现在爬的部分网站证书有些问题，chrome会提示“链接存在安全隐患”。自己去写中间件感觉不是很方便，这样在setting添加一下配置就可以了。