### PR TITLE
修复mongodb的update_items方法

### DIFF
--- a/feapder/pipelines/mongo_pipeline.py
+++ b/feapder/pipelines/mongo_pipeline.py
@@ -57,10 +57,16 @@ class MongoPipeline(BasePipeline):
                  若False，不会将本批数据入到去重库，以便再次入库
 
         """
+        update_values = []
+        for key in update_keys:
+            for item in items:
+                update_values.append(item[key])
+
         update_count = self.to_db.add_batch(
             coll_name=table,
             datas=items,
             update_columns=update_keys or list(items[0].keys()),
+            update_columns_value=update_values,
         )
         if update_count:
             msg = "共更新 %s 条数据 到 %s" % (update_count, table)


### PR DESCRIPTION
原来的mongo pipeline的update_items中缺少update_columns_value，会导致mongo数据更新失败。现在是直接根据update_keys去获取需要的update_columns_value，不知道有没有更好的方案。