### PR TITLE
修复在3.10报导入错误，#123

### DIFF
--- a/feapder/core/parser_control.py
+++ b/feapder/core/parser_control.py
@@ -10,7 +10,10 @@ Created on 2017-01-03 16:06
 import random
 import threading
 import time
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import feapder.setting as setting
 import feapder.utils.tools as tools

--- a/feapder/core/scheduler.py
+++ b/feapder/core/scheduler.py
@@ -9,7 +9,10 @@ Created on 2017-01-09 10:38
 """
 import threading
 import time
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import feapder.setting as setting
 import feapder.utils.tools as tools

--- a/feapder/core/spiders/batch_spider.py
+++ b/feapder/core/spiders/batch_spider.py
@@ -12,7 +12,10 @@ import datetime
 import os
 import time
 import warnings
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import feapder.setting as setting
 import feapder.utils.tools as tools

--- a/feapder/core/spiders/spider.py
+++ b/feapder/core/spiders/spider.py
@@ -10,7 +10,10 @@ Created on 2020/4/22 12:05 AM
 
 import time
 import warnings
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import feapder.setting as setting
 import feapder.utils.tools as tools


### PR DESCRIPTION
修复在`Python 3.10`下，报`cannot import name 'Iterable' from 'collections'`错误。原因是`Python 3.10`中，`Iterable`位于`collections.abc`，而不再是`collections`下了。