### PR TITLE
BUG: 修复lpop中读取两次列表长度引起的数据异常

### DIFF
--- a/feapder/db/redisdb.py
+++ b/feapder/db/redisdb.py
@@ -607,8 +607,8 @@ class RedisDB:
         """
 
         datas = None
-
-        count = count if count <= self.lget_count(table) else self.lget_count(table)
+        lcount = self.lget_count(table)
+        count = count if count <= lcount else lcount
 
         if count:
             if count > 1:


### PR DESCRIPTION
两次读取长度获取到的结果有可能不一样，导致返回的数据格式不符合预期。在我实际使用中就遇到了这个问题，排查了蛮久。。。