### PR TITLE
fix:处理在exception_request中返回新的Request对象没有设置parser_name属性，导致无法发送请求的问题

### DIFF
--- a/feapder/core/parser_control.py
+++ b/feapder/core/parser_control.py
@@ -286,6 +286,8 @@ class ParserControl(threading.Thread):
                         if not isinstance(request, Request):
                             raise Exception("exception_request 需 yield request")
 
+                        # 给request的 parser_name 赋值
+                        request.parser_name = request.parser_name or parser.name
                         if (
                             request.retry_times + 1 > setting.SPIDER_MAX_RETRY_TIMES
                             or request.is_abandoned
@@ -638,6 +640,8 @@ class AirSpiderParserControl(ParserControl):
                         if not isinstance(request, Request):
                             raise Exception("exception_request 需 yield request")
 
+                        # 给request的 parser_name 赋值
+                        request.parser_name = request.parser_name or parser.name
                         if (
                             request.retry_times + 1 > setting.SPIDER_MAX_RETRY_TIMES
                             or request.is_abandoned


### PR DESCRIPTION
处理在exception_request中返回新的Request对象没有设置parser_name属性，导致无法发送请求的问题