### PR TITLE
修改PyExecJS为PyExecJS2库，可在多线程中执行

### DIFF
--- a/feapder/requirements.txt
+++ b/feapder/requirements.txt
@@ -1,7 +1,7 @@
 better-exceptions>=0.2.2
 DBUtils>=2.0
 parsel>=1.5.2
-PyExecJS>=1.5.1
+PyExecJS2>=1.6.1
 pymongo>=3.10.1
 PyMySQL>=0.9.3
 redis>=2.10.6,<4.0.0


### PR DESCRIPTION
在download_middlerware 中动态修改headers里面token需要调用js_code时使用PyExecJS会报错，改为PyExecJS2可解决此问题！