### PR TITLE
docs:update proxy.md,request has no attribute  proxies 

### DIFF
--- a/docs/source_code/proxy.md
+++ b/docs/source_code/proxy.md
@@ -96,8 +96,10 @@ class TestProxy(feapder.AirSpider):
         yield feapder.Request("https://www.baidu.com")
         
     def download_midware(self, request):
-        # 这里随机取个代理使用即可
-        request.proxies = {"https": "https://ip:port", "http": "http://ip:port"} 
+        # 这里随机取个代理使用即可,
+        #proxies 是requests的参数,需要通过request.requests_kwargs传递
+        request.requests_kwargs = {}
+        request.requests_kwargs['proxies'] = {"https": "https://ip:port", "http": "http://ip:port"}
         return request
 
     def parse(self, request, response):


### PR DESCRIPTION
当用户要自己给 request 赋值代理时,
 proxies 属性值并不在 request 下,而是在 request.requests_kwargs下